### PR TITLE
Support non-snap installs

### DIFF
--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -196,6 +196,7 @@ $SUDO echo "ro.opengles.version=131072" >> ./squashfs-root/system/build.prop
 
 #squash img
 cd "$WORKDIR"
+echo "rebaking android.img"
 rm android.img
 $SUDO $MKSQUASHFS squashfs-root android.img -b 131072 -comp xz -Xbcj x86
 

--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -110,9 +110,8 @@ $SUDO $UNSQUASHFS android.img
 cd "$WORKDIR"
 if [ ! -f ./$OPENGAPPS_FILE ]; then
   $WGET -q --show-progress $OPENGAPPS_URL
-  $UNZIP -d opengapps ./$OPENGAPPS_FILE
 fi
-
+[ -d opengapps ] || $UNZIP -d opengapps ./$OPENGAPPS_FILE
 
 cd ./opengapps/Core/
 for filename in *.tar.lz


### PR DESCRIPTION
As debian has got anbox packaged in their repo now, there's going to be a growing number of non-snap installations (https://qa.debian.org/popcon.php?package=anbox) ..
Now I got to clean up my quick & dirty local hack for you to preview and comment. I can rebase these changes to current master later but it will need some more time (weeks!).