### PR TITLE
feat: use latest releasedate for opengapps

### DIFF
--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -27,7 +27,7 @@
 # die when an error occurs
 set -e
 
-OPENGAPPS_RELEASEDATE="20180903"
+OPENGAPPS_RELEASEDATE="$(curl -s https://api.github.com/repos/opengapps/x86_64/releases/latest | head -n 10 | grep tag_name | grep -o "\"[0-9][0-9]*\"" | grep -o "[0-9]*")" # get latest releasedate based on tag_name for latest x86_64 build
 OPENGAPPS_FILE="open_gapps-x86_64-7.1-mini-$OPENGAPPS_RELEASEDATE.zip"
 OPENGAPPS_URL="https://github.com/opengapps/x86_64/releases/download/$OPENGAPPS_RELEASEDATE/$OPENGAPPS_FILE"
 


### PR DESCRIPTION
Uses curl and a bit of coreutils wizardy to extract the tag_name for x86_64 latest

I could've used `jq` but not everyone has that installed so I went for coreutils as it's really not that complex