### PR TITLE
temporary fix for releasedate query

### DIFF
--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -98,7 +98,8 @@ fi
 
 
 # get latest releasedate based on tag_name for latest x86_64 build
-OPENGAPPS_RELEASEDATE="$($CURL -s https://api.github.com/repos/opengapps/x86_64/releases/latest | head -n 10 | grep tag_name | grep -o "\"[0-9][0-9]*\"" | grep -o "[0-9]*")" 
+#OPENGAPPS_RELEASEDATE="$($CURL -s https://api.github.com/repos/opengapps/x86_64/releases/latest | head -n 10 | grep tag_name | grep -o "\"[0-9][0-9]*\"" | grep -o "[0-9]*")" 
+OPENGAPPS_RELEASEDATE="$($CURL -s https://sourceforge.net/projects/opengapps/files/x86_64/ | grep "<span class=\"sub-label\">open_gapps-arm64-9.0-nano-" | awk -F'[-.]' '{print $7}')" 
 OPENGAPPS_FILE="open_gapps-x86_64-7.1-mini-$OPENGAPPS_RELEASEDATE.zip"
 OPENGAPPS_URL="https://sourceforge.net/projects/opengapps/files/x86_64/$OPENGAPPS_RELEASEDATE/$OPENGAPPS_FILE"
 


### PR DESCRIPTION
github project opengapps/x86_64 is currently blocked and will probably stay this way as opengapps abandoned github and migrated to sourceforge.
the fix i suggested adds a few seconds (because of the extremely inefficient query of the html) but that's the only quick way i found and it's much better than nothing because otherwise it fails the script completely without even an error message.