### PR TITLE
Fix for issue #54 and #66

### DIFF
--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -152,6 +152,15 @@ if [ ! -d "$COMBINEDDIR" ]; then
 		$SUDO snap set anbox rootfs-overlay.enable=true
 		$SUDO snap restart anbox.container-manager
 	else
+		# As fix for https://github.com/geeks-r-us/anbox-playstore-installer/issues/54 so none need manually create the structure
+		# Author @NickWilde263 (Just call me Fox)
+	        # "mkdir" won't report error when the path already exist because of "-p" see "man mkdir" about "-p" option
+		if [ ! -d "/etc/systemd/system/anbox-container-manager.service.d/" ]; then
+			# Informing the user about creation of the directory
+			echo "Creating /etc/systemd/system/anbox-container-manager.service.d/ directory"
+			$SUDO mkdir -p /etc/systemd/system/anbox-container-manager.service.d/override.conf
+		fi
+		
 		$SUDO cat >/etc/systemd/system/anbox-container-manager.service.d/override.conf<<EOF
 [Service]
 ExecStart=

--- a/install-playstore.sh
+++ b/install-playstore.sh
@@ -158,7 +158,7 @@ if [ ! -d "$COMBINEDDIR" ]; then
 		if [ ! -d "/etc/systemd/system/anbox-container-manager.service.d/" ]; then
 			# Informing the user about creation of the directory
 			echo "Creating /etc/systemd/system/anbox-container-manager.service.d/ directory"
-			$SUDO mkdir -p /etc/systemd/system/anbox-container-manager.service.d/override.conf
+			$SUDO mkdir -p /etc/systemd/system/anbox-container-manager.service.d/
 		fi
 		
 		$SUDO cat >/etc/systemd/system/anbox-container-manager.service.d/override.conf<<EOF


### PR DESCRIPTION
1. Users no longer need manually create the missing directory
2. Report the user when creating the missing directory